### PR TITLE
API-1116 log the product with each request

### DIFF
--- a/elastilog.go
+++ b/elastilog.go
@@ -81,6 +81,9 @@ func (ee *ElasticEntry) SetRequest(req *http.Request) {
 func (ee *ElasticEntry) SetUserID(id string) {
 	ee.set("request.user_id", id)
 }
+func (ee *ElasticEntry) SetProductType(pt string) {
+	ee.set("request.product_type", pt)
+}
 
 func (ee *ElasticEntry) SetResponse(status int, body interface{}) {
 	if debug || status >= 300 {


### PR DESCRIPTION
Now that the api takes requests for any product it's useful to see the product context in logging output per request.
