### PR TITLE
API-2809: Support logging product type to loggly

### DIFF
--- a/loggly.go
+++ b/loggly.go
@@ -43,14 +43,15 @@ type LogglyEntry struct {
 	Level LogLevel
 
 	Request struct {
-		Proto  string
-		Method string
-		Host   string
-		Path   string
-		Query  string
-		Body   string
-		Header http.Header
-		UserID string
+		Proto       string
+		Method      string
+		Host        string
+		Path        string
+		Query       string
+		Body        string
+		Header      http.Header
+		UserID      string
+		ProductType string
 	}
 	Response struct {
 		Body     interface{}
@@ -87,6 +88,10 @@ func (le *LogglyEntry) SetResponse(status int, body interface{}) {
 	}
 	le.Response.Status = status
 	le.Response.Duration = time.Since(le.startTime).Nanoseconds() / 1000000 //1 ms = 1000000ns
+}
+
+func (le *LogglyEntry) SetProductType(pt string) {
+	le.Request.ProductType = pt
 }
 
 func (le *LogglyEntry) Write(b []byte) (int, error) {


### PR DESCRIPTION
Verified by viewing logs in the loggly dashboard generated from a (partial) cucumber run, observing that the ProductType is now present in log records (records tagged `gonoble_Brian_local`).